### PR TITLE
Fix issues for displaying and configuring

### DIFF
--- a/app/views/hooks/redmine_tint_issues/_tint_issues_css.html.erb
+++ b/app/views/hooks/redmine_tint_issues/_tint_issues_css.html.erb
@@ -1,6 +1,11 @@
 <%= content_for :header_tags do -%>
   <%# stylesheet_link_tag "redmine_tint_issues.css", :plugin => "redmine_tint_issues" %>
 <style>
+
+table.list {
+    border-collapse: collapse;
+}
+
 /* current */
 table.list tbody tr.current:nth-child(odd)         { background-color:<%= Setting['plugin_redmine_tint_issues']['current_issue_age_color'] %>; }
 table.list tbody tr.current:nth-child(even)        { background-color:<%= rti_lighten_css_color(  Setting['plugin_redmine_tint_issues']['current_issue_age_color'], 0.05) %>; }

--- a/app/views/hooks/redmine_tint_issues/_tint_issues_css.html.erb
+++ b/app/views/hooks/redmine_tint_issues/_tint_issues_css.html.erb
@@ -8,31 +8,31 @@ table.list {
 
 /* current */
 table.list tbody tr.current:nth-child(odd)         { background-color:<%= Setting['plugin_redmine_tint_issues']['current_issue_age_color'] %>; }
-table.list tbody tr.current:nth-child(even)        { background-color:<%= rti_lighten_css_color(  Setting['plugin_redmine_tint_issues']['current_issue_age_color'], 0.05) %>; }
+table.list tbody tr.current:nth-child(even)        { background-color:<%= rti_lighten_css_color(  Setting['plugin_redmine_tint_issues']['current_issue_age_color'], -0.05) %>; }
 table.list tbody tr.current:nth-child(odd):hover   { background-color:<%= rti_contrast_css_color( Setting['plugin_redmine_tint_issues']['current_issue_age_color']) %>; }
 table.list tbody tr.current:nth-child(even):hover  { background-color:<%= rti_contrast_css_color( Setting['plugin_redmine_tint_issues']['current_issue_age_color']) %>; }
 
 /* old */
 table.list tbody tr.old:nth-child(odd)             { background-color:<%= Setting['plugin_redmine_tint_issues']['old_issue_age_color'] %>; }
-table.list tbody tr.old:nth-child(even)            { background-color:<%= rti_lighten_css_color(  Setting['plugin_redmine_tint_issues']['old_issue_age_color'], 0.05) %>; }
+table.list tbody tr.old:nth-child(even)            { background-color:<%= rti_lighten_css_color(  Setting['plugin_redmine_tint_issues']['old_issue_age_color'], -0.05) %>; }
 table.list tbody tr.old:nth-child(odd):hover       { background-color:<%= rti_contrast_css_color( Setting['plugin_redmine_tint_issues']['old_issue_age_color']) %>; }
 table.list tbody tr.old:nth-child(even):hover      { background-color:<%= rti_contrast_css_color( Setting['plugin_redmine_tint_issues']['old_issue_age_color']) %>; }
 
 /* older */
 table.list tbody tr.older:nth-child(odd)           { background-color:<%= Setting['plugin_redmine_tint_issues']['older_issue_age_color'] %>; }
-table.list tbody tr.older:nth-child(even)          { background-color:<%= rti_lighten_css_color(  Setting['plugin_redmine_tint_issues']['older_issue_age_color'], 0.05) %>; }
+table.list tbody tr.older:nth-child(even)          { background-color:<%= rti_lighten_css_color(  Setting['plugin_redmine_tint_issues']['older_issue_age_color'], -0.05) %>; }
 table.list tbody tr.older:nth-child(odd):hover     { background-color:<%= rti_contrast_css_color( Setting['plugin_redmine_tint_issues']['older_issue_age_color']) %>; }
 table.list tbody tr.older:nth-child(even):hover    { background-color:<%= rti_contrast_css_color( Setting['plugin_redmine_tint_issues']['older_issue_age_color']) %>; }
 
 /* veryold */
 table.list tbody tr.veryold:nth-child(odd)         { background-color:<%= Setting['plugin_redmine_tint_issues']['veryold_issue_age_color'] %>; }
-table.list tbody tr.veryold:nth-child(even)        { background-color:<%= rti_lighten_css_color(  Setting['plugin_redmine_tint_issues']['veryold_issue_age_color'], 0.05) %>; }
+table.list tbody tr.veryold:nth-child(even)        { background-color:<%= rti_lighten_css_color(  Setting['plugin_redmine_tint_issues']['veryold_issue_age_color'], -0.05) %>; }
 table.list tbody tr.veryold:nth-child(odd):hover   { background-color:<%= rti_contrast_css_color( Setting['plugin_redmine_tint_issues']['veryold_issue_age_color']) %>; }
 table.list tbody tr.veryold:nth-child(even):hover  { background-color:<%= rti_contrast_css_color( Setting['plugin_redmine_tint_issues']['veryold_issue_age_color']) %>; }
 
 /* ancient */
 table.list tbody tr.ancient:nth-child(odd)         { background-color:<%= Setting['plugin_redmine_tint_issues']['ancient_issue_age_color'] %>; }
-table.list tbody tr.ancient:nth-child(even)        { background-color:<%= rti_lighten_css_color(  Setting['plugin_redmine_tint_issues']['ancient_issue_age_color'], 0.05) %>; }
+table.list tbody tr.ancient:nth-child(even)        { background-color:<%= rti_lighten_css_color(  Setting['plugin_redmine_tint_issues']['ancient_issue_age_color'], -0.05) %>; }
 table.list tbody tr.ancient:nth-child(odd):hover   { background-color:<%= rti_contrast_css_color( Setting['plugin_redmine_tint_issues']['ancient_issue_age_color']) %>; }
 table.list tbody tr.ancient:nth-child(even):hover  { background-color:<%= rti_contrast_css_color( Setting['plugin_redmine_tint_issues']['ancient_issue_age_color']) %>; }
 

--- a/app/views/hooks/redmine_tint_issues/_tint_issues_css.html.erb
+++ b/app/views/hooks/redmine_tint_issues/_tint_issues_css.html.erb
@@ -2,10 +2,6 @@
   <%# stylesheet_link_tag "redmine_tint_issues.css", :plugin => "redmine_tint_issues" %>
 <style>
 
-table.list {
-    border-collapse: collapse;
-}
-
 /* current */
 table.list tbody tr.current:nth-child(odd)         { background-color:<%= Setting['plugin_redmine_tint_issues']['current_issue_age_color'] %>; }
 table.list tbody tr.current:nth-child(even)        { background-color:<%= rti_lighten_css_color(  Setting['plugin_redmine_tint_issues']['current_issue_age_color'], -0.05) %>; }
@@ -37,65 +33,80 @@ table.list tbody tr.ancient:nth-child(odd):hover   { background-color:<%= rti_co
 table.list tbody tr.ancient:nth-child(even):hover  { background-color:<%= rti_contrast_css_color( Setting['plugin_redmine_tint_issues']['ancient_issue_age_color']) %>; }
 
 /* hasduedate */
-table.list tbody tr:nth-child(odd).hasduedate,
-table.list tbody tr:nth-child(even).hasduedate
+table.list tbody tr.hasduedate td:first-of-type
     {
     border-left-style: solid;
-    border-right-style: solid;
     border-left-width: 5px;
     border-left-color: <%= Setting['plugin_redmine_tint_issues']['hasduedate_color'] %>;
+    border-collapse: separate;
+    }
+table.list tbody tr.hasduedate td:last-of-type
+    {
+    border-right-style: solid;
     border-right-width: 5px;
     border-right-color:<%= Setting['plugin_redmine_tint_issues']['hasduedate_color'] %>;
     border-collapse: separate;
     }
     
 /* due */
-table.list tbody tr:nth-child(odd).due,
-table.list tbody tr:nth-child(even).due
+table.list tbody tr.due td:first-of-type
     {
     border-left-style: solid;
-    border-right-style: solid;
     border-left-width: 5px;
     border-left-color: <%= Setting['plugin_redmine_tint_issues']['due_since_color'] %>;
+    border-collapse: separate;
+    }
+table.list tbody tr.due td:last-of-type
+    {
+    border-right-style: solid;
     border-right-width: 5px;
     border-right-color: <%= Setting['plugin_redmine_tint_issues']['due_since_color'] %>;
     border-collapse: separate;
     }
     
 /* moredue */
-table.list tbody tr:nth-child(odd).moredue,
-table.list tbody tr:nth-child(even).moredue
+table.list tbody tr.moredue td:first-of-type
     {
     border-left-style: solid;
-    border-right-style: solid;
     border-left-width: 5px;
     border-left-color: <%= Setting['plugin_redmine_tint_issues']['moredue_since_color'] %>;
+    border-collapse: separate;
+    }
+table.list tbody tr.moredue td:last-of-type
+    {
+    border-right-style: solid;
     border-right-width: 5px;
     border-right-color: <%= Setting['plugin_redmine_tint_issues']['moredue_since_color'] %>;
     border-collapse: separate;
     }
     
 /* verydue */
-table.list tbody tr:nth-child(odd).verydue,
-table.list tbody tr:nth-child(even).verydue
+table.list tbody tr.verydue td:first-of-type
     {
     border-left-style: solid;
-    border-right-style: solid;
     border-left-width: 5px;
     border-left-color: <%= Setting['plugin_redmine_tint_issues']['verydue_since_color'] %>;
+    border-collapse: separate;
+    }
+table.list tbody tr.verydue td:last-of-type
+    {
+    border-right-style: solid;
     border-right-width: 5px;
     border-right-color: <%= Setting['plugin_redmine_tint_issues']['verydue_since_color'] %>;
     border-collapse: separate;
     }
     
 /* overdue */
-table.list tbody tr:nth-child(odd).overdue,
-table.list tbody tr:nth-child(even).overdue
+table.list tbody tr.overdue td:first-of-type
     {
     border-left-style: solid;
-    border-right-style: solid;
     border-left-width: 5px;
     border-left-color: <%= Setting['plugin_redmine_tint_issues']['overdue_color'] %>;
+    border-collapse: separate;
+    }
+table.list tbody tr.overdue td:last-of-type
+    {
+    border-right-style: solid;
     border-right-width: 5px;
     border-right-color: <%= Setting['plugin_redmine_tint_issues']['overdue_color'] %>;
     border-collapse: separate;

--- a/app/views/redmine_tint_issues_plugin_settings/_settings.html.erb
+++ b/app/views/redmine_tint_issues_plugin_settings/_settings.html.erb
@@ -143,14 +143,18 @@
 
 <fieldset class="box"><legend><%= l('redmine_tint_issues.label_issue_age_base') %></legend>
   <p>
-    <%= label_tag( 'settings[age_by_creation_date]', l('redmine_tint_issues.label_age_by_creation_date')) %>
-    <%= radio_button_tag( 'settings[age_by_creation_date]', '1', settings['age_by_creation_date'] == '1') %>
+    <label>
+      <%= l('redmine_tint_issues.label_age_by_creation_date') %>
+      <%= radio_button_tag( 'settings[age_by_creation_date]', '1', settings['age_by_creation_date'] == '1') %>
+    </label>
     <%= content_tag(:a,    l(:label_help), :href => "#", :class => "icon icon-help", :title => l(:label_help), :onclick => "$('#help_settings_age_by_creation_date').toggle(); return false;" ) %>
     <%= content_tag(:span, l('redmine_tint_issues.help_settings_age_by_creation_date'), :id => 'help_settings_age_by_creation_date', :style => 'display:none;') %>
   </p>
   <p>
-    <%= label_tag( 'settings[age_by_creation_date]', l('redmine_tint_issues.label_age_by_update_date')) %>
-    <%= radio_button_tag( 'settings[age_by_creation_date]', '0', settings['age_by_creation_date'] == '0') %>
+    <label>
+      <%= l('redmine_tint_issues.label_age_by_update_date') %>
+      <%= radio_button_tag( 'settings[age_by_creation_date]', '0', settings['age_by_creation_date'] == '0') %>
+    </label>
     <%= content_tag(:a, l(:label_help), :href => "#", :class => "icon icon-help", :title => l(:label_help), :onclick => "$('#help_settings_age_by_update_date').toggle(); return false;" ) %>
     <%= content_tag(:span, l('redmine_tint_issues.help_settings_age_by_update_date'), :id => 'help_settings_age_by_update_date', :style => 'display:none;') %>
   </p>

--- a/app/views/redmine_tint_issues_plugin_settings/_settings.html.erb
+++ b/app/views/redmine_tint_issues_plugin_settings/_settings.html.erb
@@ -1,3 +1,22 @@
+<fieldset class="box"><legend><%= l('redmine_tint_issues.label_issue_age_base') %></legend>
+  <p>
+    <label>
+      <%= l('redmine_tint_issues.label_age_by_creation_date') %>
+      <%= radio_button_tag( 'settings[age_by_creation_date]', '1', settings['age_by_creation_date'] == '1') %>
+    </label>
+    <%= content_tag(:a,    l(:label_help), :href => "#", :class => "icon icon-help", :title => l(:label_help), :onclick => "$('#help_settings_age_by_creation_date').toggle(); return false;" ) %>
+    <%= content_tag(:span, l('redmine_tint_issues.help_settings_age_by_creation_date'), :id => 'help_settings_age_by_creation_date', :style => 'display:none;') %>
+  </p>
+  <p>
+    <label>
+      <%= l('redmine_tint_issues.label_age_by_update_date') %>
+      <%= radio_button_tag( 'settings[age_by_creation_date]', '0', settings['age_by_creation_date'] == '0') %>
+    </label>
+    <%= content_tag(:a, l(:label_help), :href => "#", :class => "icon icon-help", :title => l(:label_help), :onclick => "$('#help_settings_age_by_update_date').toggle(); return false;" ) %>
+    <%= content_tag(:span, l('redmine_tint_issues.help_settings_age_by_update_date'), :id => 'help_settings_age_by_update_date', :style => 'display:none;') %>
+  </p>
+</fieldset>
+
 <table class="list issues">
   <tr class="issue current">
       <td align="left" width="33%" style="text-align:left;width=33%;">
@@ -140,25 +159,6 @@
       </td>
   </tr>
 </table>
-
-<fieldset class="box"><legend><%= l('redmine_tint_issues.label_issue_age_base') %></legend>
-  <p>
-    <label>
-      <%= l('redmine_tint_issues.label_age_by_creation_date') %>
-      <%= radio_button_tag( 'settings[age_by_creation_date]', '1', settings['age_by_creation_date'] == '1') %>
-    </label>
-    <%= content_tag(:a,    l(:label_help), :href => "#", :class => "icon icon-help", :title => l(:label_help), :onclick => "$('#help_settings_age_by_creation_date').toggle(); return false;" ) %>
-    <%= content_tag(:span, l('redmine_tint_issues.help_settings_age_by_creation_date'), :id => 'help_settings_age_by_creation_date', :style => 'display:none;') %>
-  </p>
-  <p>
-    <label>
-      <%= l('redmine_tint_issues.label_age_by_update_date') %>
-      <%= radio_button_tag( 'settings[age_by_creation_date]', '0', settings['age_by_creation_date'] == '0') %>
-    </label>
-    <%= content_tag(:a, l(:label_help), :href => "#", :class => "icon icon-help", :title => l(:label_help), :onclick => "$('#help_settings_age_by_update_date').toggle(); return false;" ) %>
-    <%= content_tag(:span, l('redmine_tint_issues.help_settings_age_by_update_date'), :id => 'help_settings_age_by_update_date', :style => 'display:none;') %>
-  </p>
-</fieldset>
 
 <%= javascript_include_tag "jscolor.js", :plugin => "redmine_tint_issues" %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,7 +40,7 @@ en:
     settings_label_due: '"due" is closer than'
     settings_label_moredue: '"more due" is closer than'
     settings_label_verydue: '"very due" is closer than'
-    settings_label_overdue: 'overdue '
+    settings_label_overdue: 'overdue'
     settings_label_nochoice: 'no possible choice'
     
     label_issue_age_base: "Issue age base"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,14 +36,14 @@ en:
     settings_label_weeks: 'weeks'
     settings_label_months: 'months'
   
-    settings_label_hasduedate: 'has due date'
+    settings_label_hasduedate: 'Has due date'
     settings_label_due: '"due" is closer than'
     settings_label_moredue: '"more due" is closer than'
     settings_label_verydue: '"very due" is closer than'
-    settings_label_overdue: 'overdue'
+    settings_label_overdue: 'Overdue'
     settings_label_nochoice: 'no possible choice'
     
-    label_issue_age_base: "Issue age base"
+    label_issue_age_base: "Issue age base (without start date)"
     label_age_by_creation_date: "Age by creation date"
     help_settings_age_by_creation_date: "Calculate issue age by creation date."
     label_age_by_update_date: "Age by update date"


### PR DESCRIPTION
- Fix: Chrome does not display left and right boders for due date - https://stackoverflow.com/questions/18679020/border-around-tr-element-doesnt-show
- Fix: display darker background colors for `tr`-s with `nth-child(even)` - the background colors are generally light, and lightening a light color may get white, which looks like a bug
- Fix: radio labels does not work
- Move "issue age base" to the top of the page, which is close to the "issue age table"